### PR TITLE
Use correct names in pseudoclass regex

### DIFF
--- a/src/__tests__/transformClassName.test.js
+++ b/src/__tests__/transformClassName.test.js
@@ -11,6 +11,10 @@ describe("transformClassName", () => {
     ${".sm:bg-red-400"}                                   | ${"sm:bg-red-400"}
     ${`.focus\:bg-orange-100:focus`}                      | ${`focus:bg-orange-100`}
     ${".lg:hover:text-purple-600:hover"}                  | ${"lg:hover:text-purple-600"}
+    ${".last\:rounded-b:last-child"}                      | ${"last:rounded-b"}
+    ${".first\:rounded-t:first-child"}                    | ${"first:rounded-t"}
+    ${".odd\:text-purple-600:nth-child(odd)"}             | ${"odd:text-purple-600"}
+    ${".even\:text-purple-600:nth-child(even)"}           | ${"even:text-purple-600"}
   `(
     "returns $expected when className is $classname",
     ({ classname, expected }) => {

--- a/src/transformClassName.js
+++ b/src/transformClassName.js
@@ -14,7 +14,7 @@ const transformClassname = (cn) => {
 
   // handle psuedo classes
   cls = cls.replace(
-    /\:(responsive|group-hover|focus-within|first|last|odd|even|hover|focus|active|visited|disabled|group:hover|group:focus)$/,
+    /\:(responsive|group-hover|focus-within|first-child|last-child|nth-child\((odd|even)\)|hover|focus|active|visited|disabled|group:hover|group:focus)$/,
     ""
   );
   // remove extras at end


### PR DESCRIPTION
Hey!

Some of the pseudo classes names were wrong in the regex thus generating invalid class names, this patch fixes it.

Using this library with reason has been a breeze, thanks for your hard work!