### PR TITLE
Handle selectors with spaces correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const writeClass = (c) => {
 };
 
 const make = (classes) => {
-  const twNames = uniq(classes.map(transformClassName));
+  const twNames = classes.map(transformClassName);
   return twNames.map(writeClass).join("\n");
 };
 
@@ -22,6 +22,7 @@ module.exports = postcss.plugin("postcss-bs-tailwind", (opts = {}) => {
     root.walkRules((rule) => {
       classes = classes.concat(filterClassNamesForProcessing(rule.selector));
     });
+    classes = uniq(classes);
 
     fs.writeFileSync(path.join(process.cwd(), modulePath), make(classes), {
       encoding: "utf8",

--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ module.exports = postcss.plugin("postcss-bs-tailwind", (opts = {}) => {
 
       const arr = rule.selector.split(" ");
       if (arr.length > 1) {
-        cn = arr[arr.length - 1];
+        arr.filter(s => s.startsWith(".")).forEach(cn => classes.push(cn));
+      } else {
+        classes.push(cn);
       }
-
-      classes.push(cn);
     });
 
     fs.writeFileSync(path.join(process.cwd(), modulePath), make(classes), {

--- a/src/__tests__/filterClassNamesForProcessing.test.js
+++ b/src/__tests__/filterClassNamesForProcessing.test.js
@@ -1,0 +1,17 @@
+const filterClassNamesForProcessing = require("../filterClassNamesForProcessing");
+
+describe("filterClassNamesForProcessing", () => {
+    test.each`
+        selector                                                | expected
+        ${"h1 h2"}                                              | ${[]}
+        ${".space-x-0"}                                         | ${[".space-x-0"]}
+        ${".group:hover .group-hover\\:rounded"}                | ${[".group:hover", ".group-hover\\:rounded"]}
+        ${".class1.class2 .class3"}                             | ${[".class1", ".class2", ".class3"]}
+        ${".space-y-0 > :not(template) ~ :not(template)"}       | ${[".space-y-0"]}
+    `(
+        "return $expected when selector is $selector",
+        ({selector, expected}) => {
+            expect(filterClassNamesForProcessing(selector)).toEqual(expected);
+        }
+    );
+});

--- a/src/filterClassNamesForProcessing.js
+++ b/src/filterClassNamesForProcessing.js
@@ -1,0 +1,26 @@
+const { chain } = require("lodash");
+
+const filterClassNamesForProcessing = (selector) => {
+        if (!selector.startsWith(".")
+            || selector.trim().length === 0) {
+          // keep only classes
+          return [];
+        }
+
+        const arr = selector.split(" ");
+        if (arr.length === 1) { // Avoid heavy processing in single classes 
+            return arr;
+        }
+        if (arr.length > 1) {
+            return chain(arr)
+                .filter(sel => sel.includes(".")) // Check for selectors that are classes
+                .flatMap(cns => cns.split(".") // Split possibly chained classes like '.a.b.c'
+                        .filter(cn => cn.length > 0) // Call to split(".") might've added empty strings, remove them
+                        .map(cn => `.${cn}`)) // Add dot lost in cns.split(".") to every class
+                .value(); 
+        } else {
+          return arr;
+        }
+      };
+
+module.exports = filterClassNamesForProcessing;


### PR DESCRIPTION
Hey again!

Found a bug in the handling of selectors with spaces in two instances, for the group:* variants and the new space between utilities (Tailwind 1.30+).

For the group:* variants the parent needs the `.group` class, but since the group:* selector is written as e.g. `.group:hover .group-hover\:rounded` the `.group` selector was being dropped thus making the second selector useless.

In the space between case, the selector is written as e.g. `.space-y-0 > :not(template) ~ :not(template)` which translates to reason as `__not(template) = ".."` (a function that takes a parameter template and returns a string :P ) thus making the feature unavailable.

This patch tries to fix the issues by getting all the classes in the selector and adding  them to the classes array for processing.

I don't know how to write a test for the postcss part of the plugin, so heres a little PoC that works now, (didn't before):

```
<div className={Cn.make([flex, space_x_2, group, p_2])}>                                                                            
       <div className={Cn.make([flex, group_hover__rounded, px_2, border, border_red_700])}>{"X" |> React.string}</div>                
       <div className={Cn.make([flex, group_hover__rounded, px_2, border, border_red_700])}>{"y" |> React.string}</div>                
       <div className={Cn.make([flex, group_hover__rounded, px_2, border, border_red_700])}>{"z" |> React.string}</div>                
</div>
```

You'll need to configure the variants in the tailwind.config.js file like so to make the group-hover variant available:
```
variants: {
        borderRadius: ['group-hover']
}
```
If you think theres a better way to handle these cases or some others that I might have missed tell me and I'll gladly add them to the patch.

Cheers